### PR TITLE
cmake: copy a few missing dependencies for Windows

### DIFF
--- a/cmake/Modules/CopyMSVCBins.cmake
+++ b/cmake/Modules/CopyMSVCBins.cmake
@@ -65,6 +65,12 @@ file(GLOB FFMPEG_BIN_FILES
 	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin/libvpx*.dll"
 	"${FFMPEG_avcodec_INCLUDE_DIR}/bin/libvpx*.dll"
 
+	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin/libsrt*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/bin/libsrt*.dll"
+
+	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin/libmbedcrypto*.dll"
+	"${FFMPEG_avcodec_INCLUDE_DIR}/bin/libmbedcrypto*.dll"
+
 	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin${_bin_suffix}/libopus*.dll"
 	"${FFMPEG_avcodec_INCLUDE_DIR}/../bin${_bin_suffix}/opus*.dll"
 	"${FFMPEG_avcodec_INCLUDE_DIR}/bin${_bin_suffix}/libopus*.dll"


### PR DESCRIPTION
This issue was observed as the linked submodules and their dependencies were missing in the forked version